### PR TITLE
[grid] Moved `isDeleted` from default buttons

### DIFF
--- a/grid/ActionColumn.php
+++ b/grid/ActionColumn.php
@@ -36,7 +36,11 @@ class ActionColumn extends \yii\grid\ActionColumn
      */
     public $template = '{view} {update} {delete}{restore}';
 
-
+    /**
+     * @var string Set your model's attribute for `SoftDeleteBehavior`.
+     */
+    public $softDeleteAttribute = 'isDeleted';
+    
     /**
      * Merges buttons with default configurations.
      */
@@ -64,8 +68,8 @@ class ActionColumn extends \yii\grid\ActionColumn
                     'icon' => 'trash',
                     'visible' => function ($model) {
                         /* @var $model \yii\db\BaseActiveRecord */
-                        if (is_object($model) && $model->canGetProperty('isDeleted')) {
-                            return !$model->isDeleted;
+                        if (is_object($model) && $model->canGetProperty($this->softDeleteAttribute)) {
+                            return !$model->{$this->softDeleteAttribute};
                         }
                         return true;
                     },
@@ -81,8 +85,8 @@ class ActionColumn extends \yii\grid\ActionColumn
                     'icon' => 'repeat',
                     'visible' => function ($model) {
                         /* @var $model \yii\db\BaseActiveRecord */
-                        if (is_object($model) && $model->canGetProperty('isDeleted')) {
-                            return $model->isDeleted;
+                        if (is_object($model) && $model->canGetProperty($this->softDeleteAttribute)) {
+                            return $model->{$this->softDeleteAttribute};
                         }
                         return false;
                     },


### PR DESCRIPTION
Thanks for the admin pack, it's very useful!

I wanted to change my `SoftDeleteBehavior` attribute for ActionColumns, but didn't find a way to do so with one field config.

So I moved direct `isDeleted` attribute usage from `initDefaultButtons()` function to separate public field `softDeleteAttribute` in order to allow to redefine the attribute, without reassigning `buttons` array.

Hope that's useful.